### PR TITLE
Properly unbind resize event in unSyncHeight()

### DIFF
--- a/jquery.syncheight.js
+++ b/jquery.syncheight.js
@@ -96,7 +96,7 @@
 
     // optional sync refresh on resize event ...
     if (options.updateOnResize === true) {
-      $(window).resize(function(){
+      $(window).bind('resize.syncHeight', function(){
         $(e).syncHeight();
       });
     }
@@ -104,6 +104,9 @@
   };
 
   $.fn.unSyncHeight = function() {
+    // unbind optional resize event ...
+    $(window).unbind('resize.syncHeight');
+
     var heightPropertyName = getHeightProperty().name;
     $(this).each(function() {
       $(this).css(heightPropertyName, '');


### PR DESCRIPTION
Fixes #8: Updated `syncHeight()` with namespace on resize event; added unbind of resize event in `unSyncHeight()`. 

Kept `bind()`/`unbind()` syntax for backward-compatibility, but if using jQuery 1.7+ it should be `on()`/`off()` instead.
